### PR TITLE
main: safer unsafe

### DIFF
--- a/main.go
+++ b/main.go
@@ -161,10 +161,7 @@ func (st *Stats) HandleFile(path string) error {
 		mincoreSize := (batch + int64(pageSize) - 1) / int64(pageSize)
 		mincoreVec := make([]byte, mincoreSize)
 
-		batchPtr := uintptr(batch)
-		mincoreVecPtr := uintptr(unsafe.Pointer(&mincoreVec[0]))
-
-		ret, _, err := syscall.Syscall(syscall.SYS_MINCORE, mmPtr, batchPtr, mincoreVecPtr)
+		ret, _, err := syscall.Syscall(syscall.SYS_MINCORE, mmPtr, uintptr(batch), uintptr(unsafe.Pointer(&mincoreVec[0])))
 		if ret != 0 {
 			return fmt.Errorf("syscall SYS_MINCORE failed: %v", err)
 		}


### PR DESCRIPTION
As per [unsafe documentation](https://pkg.go.dev/unsafe#Pointer):

> If a pointer argument must be converted to uintptr for use as an argument, that conversion must appear in the call expression itself:

> The compiler handles a Pointer converted to a uintptr in the argument list of a call to a function implemented in assembly by arranging that the referenced allocated object, if any, is retained and not moved until the call completes, even though from the types alone it would appear that the object is no longer needed during the call.

PS. `mmPtr` is fine since it points to a non-movable mapping created by mmap.