### PR TITLE
main: remove unneeded os.Exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -397,7 +397,6 @@ func main() {
 	stat, err := NewStats()
 	if err != nil {
 		log.Fatalln(err)
-		os.Exit(1)
 	}
 
 	stat.Handle(flag.Args(), 0)


### PR DESCRIPTION
Fatalln is equivalent to Println() followed by a call to os.Exit(1).